### PR TITLE
MA-45

### DIFF
--- a/src/components/downloadRes.ts
+++ b/src/components/downloadRes.ts
@@ -38,7 +38,7 @@ export const downloadRes = (
       resourceUrl = resource?.resource_url;
     }
     const dirs = ReactNativeBlobUtil.fs.dirs;
-    const resExtension = resource?.resource_url.split('.').pop();
+    const resExtension = resource?.resource_url?.split('.').pop();
 
     const filePath = IS_IOS
       ? `${dirs.DocumentDir}/${lessonTitle?.replace(

--- a/src/components/downloadRes.ts
+++ b/src/components/downloadRes.ts
@@ -38,7 +38,7 @@ export const downloadRes = (
       resourceUrl = resource?.resource_url;
     }
     const dirs = ReactNativeBlobUtil.fs.dirs;
-    const resExtension = resource?.extension || resource?.resource_url.split('.').pop();
+    const resExtension = resource?.resource_url.split('.').pop();
 
     const filePath = IS_IOS
       ? `${dirs.DocumentDir}/${lessonTitle?.replace(


### PR DESCRIPTION
removes a check for `resource.extension` when adding the extension to the end of the file path. I did this because sometimes the extension in the file name is capitalized, while the `resource.extension `data is usually in lowercase, causing the file path to not exist. 